### PR TITLE
Add GitHub link to start screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -674,6 +674,67 @@
         box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
       }
 
+      /* GitHub link styling */
+      .github-link {
+        position: fixed;
+        bottom: 1rem;
+        right: 1rem;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 40px;
+        height: 40px;
+        color: rgba(107, 114, 128, 0.4);
+        background: rgba(255, 255, 255, 0.15);
+        backdrop-filter: blur(8px);
+        -webkit-backdrop-filter: blur(8px);
+        border-radius: 8px;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        transition: all 0.3s ease;
+        box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
+      }
+
+      .github-link:hover {
+        color: rgba(107, 114, 128, 0.9);
+        background: rgba(255, 255, 255, 0.35);
+        transform: scale(1.05);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+      }
+
+      /* Responsive sizing for GitHub link */
+      @media (min-width: 640px) {
+        .github-link {
+          bottom: 1.5rem;
+          right: 1.5rem;
+          width: 44px;
+          height: 44px;
+        }
+      }
+
+      @media (min-width: 768px) {
+        .github-link {
+          bottom: 2rem;
+          right: 2rem;
+          width: 48px;
+          height: 48px;
+        }
+      }
+
+      /* Ensure GitHub link doesn't interfere with safe areas */
+      @media (orientation: landscape) {
+        .github-link {
+          right: max(1rem, var(--safe-area-right));
+          bottom: max(1rem, var(--safe-area-bottom));
+        }
+      }
+
+      @media (orientation: portrait) {
+        .github-link {
+          right: max(1rem, var(--safe-area-right));
+          bottom: max(1rem, var(--safe-area-bottom));
+        }
+      }
+
       /* Base 3D glassmorphic styling for language buttons */
       .language-button-3d {
         backdrop-filter: blur(12px);
@@ -1213,7 +1274,7 @@
       class="container mx-auto p-1 sm:p-2 md:p-4 max-w-full min-h-screen max-h-screen flex items-center justify-center relative z-10"
     >
       <!-- Start Screen -->
-      <div id="start-screen" class="text-center w-full px-6 py-8">
+      <div id="start-screen" class="text-center w-full px-6 py-8 relative">
         <h1
           class="text-4xl sm:text-5xl md:text-7xl lg:text-8xl text-purple-600 mb-6 sm:mb-8 md:mb-10 title-glow title-pulse font-black"
         >
@@ -1236,6 +1297,26 @@
             🇩🇪 Deutsch
           </button>
         </div>
+        <!-- GitHub Link -->
+        <a
+          href="https://github.com/thg-muc"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="github-link"
+          aria-label="View source on GitHub"
+        >
+          <svg
+            viewBox="0 0 16 16"
+            width="20"
+            height="20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+            />
+          </svg>
+        </a>
       </div>
 
       <!-- Intro Screen -->


### PR DESCRIPTION
## Summary
- Added glassmorphic GitHub icon link in the bottom-right corner of the start screen
- Uses fixed positioning to ensure proper placement at viewport corner
- Responsive sizing across breakpoints (40px → 44px → 48px)
- Includes safe area support for landscape and portrait orientations
- Hover effects with scale animation and enhanced visual feedback
- Only visible on the language selection (start) screen